### PR TITLE
Add functionality to map case classes using Generic

### DIFF
--- a/src/test/scala/slickless/GenShapeSpec.scala
+++ b/src/test/scala/slickless/GenShapeSpec.scala
@@ -1,0 +1,42 @@
+package slickless
+
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.time.{Millis, Seconds, Span}
+import org.scalatest.{FreeSpec, Matchers}
+import shapeless.{::, HNil, Generic}
+import slick.driver.H2Driver.api._
+
+import scala.concurrent.ExecutionContext.Implicits.global
+
+class GenShapeSpec extends FreeSpec with Matchers with ScalaFutures {
+  implicit val patience = PatienceConfig(timeout = Span(1, Seconds), interval = Span(250, Millis))
+
+  case class Address(id: Long, house: Int, street: String)
+
+  class Addresss(tag: Tag) extends Table[Address](tag, "addresses") {
+    def id     = column[Long]("id", O.PrimaryKey, O.AutoInc)
+    def house  = column[Int]("house")
+    def street = column[String]("street")
+
+    def * = (id :: house :: street :: HNil).mappedWith(Generic[Address])
+  }
+
+  lazy val addresses = TableQuery[Addresss]
+
+  "slick tables with generic mappings" - {
+    "should support inserts and selects" in {
+      val db = Database.forConfig("h2")
+
+      val address = Address(1L, 29, "Acacia Road")
+
+      val action = for {
+        _   <- addresses.schema.create
+        _   <- addresses += address
+        ans <- addresses.result.head
+        _   <- addresses.schema.drop
+      } yield ans
+
+      whenReady(db.run(action)) { _ should equal(address) }
+    }
+  }
+}

--- a/src/test/scala/slickless/HListShapeSpec.scala
+++ b/src/test/scala/slickless/HListShapeSpec.scala
@@ -20,7 +20,7 @@ class HListShapeSpec extends FreeSpec with Matchers with ScalaFutures {
 
   lazy val users = TableQuery[Users]
 
-  "slick tables with shapeless mappings" - {
+  "slick tables with hlist mappings" - {
     "should support inserts and selects" in {
       val db = Database.forConfig("h2")
 
@@ -28,6 +28,7 @@ class HListShapeSpec extends FreeSpec with Matchers with ScalaFutures {
         _   <- users.schema.create
         _   <- users += 1L :: "dave@example.com" :: HNil
         ans <- users.result.head
+        _   <- users.schema.drop
       } yield ans
 
       whenReady(db.run(action)) { _ should equal (1L :: "dave@example.com" :: HNil) }


### PR DESCRIPTION
The `mappedWith` method allows a user to convert an HList shape mapping to a case class shape mapping using a `Generic`:

```scala
case class Address(id: Long, house: Int, street: String)

class Addresss(tag: Tag) extends Table[Address](tag, "addresses") {
  def id     = column[Long]("id", O.PrimaryKey, O.AutoInc)
  def house  = column[Int]("house")
  def street = column[String]("street")

  def * = (id :: house :: street :: HNil).mappedWith(Generic[Address])
}
```

I would have preferred the syntax `.as[Address]`, but I need two type parameters to fix the unpacked type (`Int :: String :: HNil`) and the case class type at the same time. If there's a way to derive the unpacked type from the packed type (the type of the hlist of columns: `Rep[Int] :: Rep[String] :: HNil`) within the signature of this method, I may be able to improve on the syntax.