### PR TITLE
Scala 2.11 cross-compilation & Slick upgrade to 3.2.0 final

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -18,7 +18,7 @@ scalacOptions ++= Seq(
 )
 
 libraryDependencies ++= Seq(
-  "com.typesafe.slick" %% "slick"           % "3.2.0-M2",
+  "com.typesafe.slick" %% "slick"           % "3.2.0",
   "com.chuusai"        %% "shapeless"       % "2.3.2",
   "org.scalatest"      %% "scalatest"       % "3.0.1"   % "test",
   "com.h2database"      % "h2"              % "1.4.191" % "test",

--- a/build.sbt
+++ b/build.sbt
@@ -3,6 +3,8 @@ organization := "io.underscore"
 version      := "0.3.1"
 scalaVersion := "2.12.1"
 
+crossScalaVersions := Seq("2.11.8", "2.12.1")
+
 licenses += ("Apache-2.0", url("http://apache.org/licenses/LICENSE-2.0"))
 
 scalacOptions ++= Seq(

--- a/src/main/scala/slickless/HListShape.scala
+++ b/src/main/scala/slickless/HListShape.scala
@@ -7,7 +7,7 @@ import slick.ast.MappedScalaType
 import slick.lifted.{ Shape, ShapeLevel, FlatShapeLevel, MappedProductShape, MappedProjection }
 
 final class HListShape[L <: ShapeLevel, M <: HList, U <: HList : ClassTag, P <: HList]
-    (val shapes: Seq[Shape[_, _, _, _]]) extends MappedProductShape[L, HList, M, U, P] {
+    (val shapes: Seq[Shape[_<: ShapeLevel, _, _, _]]) extends MappedProductShape[L, HList, M, U, P] {
 
   def buildValue(elems: IndexedSeq[Any]) =
     elems.foldRight(HNil: HList)(_ :: _)


### PR DESCRIPTION
Hello,

This PR aims to use your lib with Slick 3.2.0 with Scala 2.11.x. I've just enable the crossScalaCompilation in your build, and it seems to work (tested with `+ publishLocal`).

A new release with this scala 2.11 compatibility would be highly appreciated :) 