### PR TITLE
Version Updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ jdk:
 - oraclejdk8
 
 scala:
-- 2.11.8
-- 2.12.1
+- 2.11.12
+- 2.12.4
 
 script:
 - sbt clean coverage test coverageReport

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ by [Richard Dallaway][d6y],
 [Miles Sabin][milessabin],
 and [Dave Gurnell][davegurnell].
 
-Copyright 2015-2017 [Underscore Consulting LLP][underscore].
+Copyright 2015-2018 [Underscore Consulting LLP][underscore].
 Licensed [Apache 2][license].
 
 ## Versions
@@ -26,8 +26,8 @@ Grab the code by adding the following to your `build.sbt`:
 
 ~~~
 libraryDependencies ++= Seq(
-  "com.typesafe.slick" %% "slick"     % "3.2.0",
-  "com.chuusai"        %% "shapeless" % "2.3.1",
+  "com.typesafe.slick" %% "slick"     % "3.2.1",
+  "com.chuusai"        %% "shapeless" % "2.3.3",
   "io.underscore"      %% "slickless" % "<<VERSION>>"
 )
 ~~~
@@ -98,9 +98,9 @@ resolvers += Resolver.sonatypeRepo("releases")
 resolvers += Resolver.sonatypeRepo("snapshots")
 
 libraryDependencies ++= Seq(
-  "com.typesafe.slick" %% "slick"     % "3.2.0",
-  "com.chuusai"        %% "shapeless" % "2.3.2",
-  "io.underscore"      %% "slickless" % "0.3.1"
+  "com.typesafe.slick" %% "slick"     % "3.2.1",
+  "com.chuusai"        %% "shapeless" % "2.3.3",
+  "io.underscore"      %% "slickless" % "0.3.3"
 )
 ~~~
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,9 +1,9 @@
 name         := "slickless"
 organization := "io.underscore"
-version      := "0.3.2"
-scalaVersion := "2.12.1"
+version      := "0.3.3"
+scalaVersion := "2.12.4"
 
-crossScalaVersions := Seq("2.11.8", "2.12.1")
+crossScalaVersions := Seq("2.11.12", "2.12.4")
 
 licenses += ("Apache-2.0", url("http://apache.org/licenses/LICENSE-2.0"))
 
@@ -20,8 +20,8 @@ scalacOptions ++= Seq(
 )
 
 libraryDependencies ++= Seq(
-  "com.typesafe.slick" %% "slick"           % "3.2.0",
-  "com.chuusai"        %% "shapeless"       % "2.3.2",
+  "com.typesafe.slick" %% "slick"           % "3.2.1",
+  "com.chuusai"        %% "shapeless"       % "2.3.3",
   "org.scalatest"      %% "scalatest"       % "3.0.1"   % "test",
   "com.h2database"      % "h2"              % "1.4.191" % "test",
   "ch.qos.logback"      % "logback-classic" % "1.1.7"   % "test"

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.13
+sbt.version=1.0.4

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.0")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.1")

--- a/src/test/scala/slickless/GenShapeSpec.scala
+++ b/src/test/scala/slickless/GenShapeSpec.scala
@@ -1,15 +1,11 @@
 package slickless
 
-import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.time.{Millis, Seconds, Span}
-import org.scalatest.{FreeSpec, Matchers}
 import shapeless.{HNil, Generic}
 import slick.jdbc.H2Profile.api._
 
 import scala.concurrent.ExecutionContext.Implicits.global
 
-class GenShapeSpec extends FreeSpec with Matchers with ScalaFutures {
-  implicit val patience = PatienceConfig(timeout = Span(90, Seconds), interval = Span(250, Millis))
+class GenShapeSpec extends Spec {
 
   case class Address(id: Long, house: Int, street: String)
 

--- a/src/test/scala/slickless/GenShapeSpec.scala
+++ b/src/test/scala/slickless/GenShapeSpec.scala
@@ -3,7 +3,7 @@ package slickless
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.time.{Millis, Seconds, Span}
 import org.scalatest.{FreeSpec, Matchers}
-import shapeless.{::, HNil, Generic}
+import shapeless.{HNil, Generic}
 import slick.jdbc.H2Profile.api._
 
 import scala.concurrent.ExecutionContext.Implicits.global

--- a/src/test/scala/slickless/GenShapeSpec.scala
+++ b/src/test/scala/slickless/GenShapeSpec.scala
@@ -9,7 +9,7 @@ import slick.jdbc.H2Profile.api._
 import scala.concurrent.ExecutionContext.Implicits.global
 
 class GenShapeSpec extends FreeSpec with Matchers with ScalaFutures {
-  implicit val patience = PatienceConfig(timeout = Span(2, Seconds), interval = Span(250, Millis))
+  implicit val patience = PatienceConfig(timeout = Span(90, Seconds), interval = Span(250, Millis))
 
   case class Address(id: Long, house: Int, street: String)
 

--- a/src/test/scala/slickless/GenShapeSpec.scala
+++ b/src/test/scala/slickless/GenShapeSpec.scala
@@ -9,7 +9,7 @@ import slick.jdbc.H2Profile.api._
 import scala.concurrent.ExecutionContext.Implicits.global
 
 class GenShapeSpec extends FreeSpec with Matchers with ScalaFutures {
-  implicit val patience = PatienceConfig(timeout = Span(1, Seconds), interval = Span(250, Millis))
+  implicit val patience = PatienceConfig(timeout = Span(2, Seconds), interval = Span(250, Millis))
 
   case class Address(id: Long, house: Int, street: String)
 

--- a/src/test/scala/slickless/HListShapeSpec.scala
+++ b/src/test/scala/slickless/HListShapeSpec.scala
@@ -9,7 +9,7 @@ import slick.jdbc.H2Profile.api._
 import scala.concurrent.ExecutionContext.Implicits.global
 
 class HListShapeSpec extends FreeSpec with Matchers with ScalaFutures {
-  implicit val patience = PatienceConfig(timeout = Span(1, Seconds), interval = Span(250, Millis))
+  implicit val patience = PatienceConfig(timeout = Span(2, Seconds), interval = Span(250, Millis))
 
   class Users(tag: Tag) extends Table[Long :: String :: HNil](tag, "users") {
     def id    = column[Long]( "id", O.PrimaryKey, O.AutoInc )

--- a/src/test/scala/slickless/HListShapeSpec.scala
+++ b/src/test/scala/slickless/HListShapeSpec.scala
@@ -1,15 +1,11 @@
 package slickless
 
-import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.time.{Millis, Seconds, Span}
-import org.scalatest.{FreeSpec, Matchers}
 import shapeless.{::, HNil}
 import slick.jdbc.H2Profile.api._
 
 import scala.concurrent.ExecutionContext.Implicits.global
 
-class HListShapeSpec extends FreeSpec with Matchers with ScalaFutures {
-  implicit val patience = PatienceConfig(timeout = Span(90, Seconds), interval = Span(250, Millis))
+class HListShapeSpec extends Spec {
 
   class Users(tag: Tag) extends Table[Long :: String :: HNil](tag, "users") {
     def id    = column[Long]( "id", O.PrimaryKey, O.AutoInc )

--- a/src/test/scala/slickless/HListShapeSpec.scala
+++ b/src/test/scala/slickless/HListShapeSpec.scala
@@ -9,7 +9,7 @@ import slick.jdbc.H2Profile.api._
 import scala.concurrent.ExecutionContext.Implicits.global
 
 class HListShapeSpec extends FreeSpec with Matchers with ScalaFutures {
-  implicit val patience = PatienceConfig(timeout = Span(2, Seconds), interval = Span(250, Millis))
+  implicit val patience = PatienceConfig(timeout = Span(90, Seconds), interval = Span(250, Millis))
 
   class Users(tag: Tag) extends Table[Long :: String :: HNil](tag, "users") {
     def id    = column[Long]( "id", O.PrimaryKey, O.AutoInc )

--- a/src/test/scala/slickless/Spec.scala
+++ b/src/test/scala/slickless/Spec.scala
@@ -1,0 +1,12 @@
+package slickless
+
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.time.{Millis, Seconds, Span}
+import org.scalatest.{FreeSpec, Matchers}
+
+abstract class Spec extends FreeSpec with Matchers with ScalaFutures {
+  implicit val patience = PatienceConfig(timeout = Span(30, Seconds), interval = Span(250, Millis))
+}
+
+
+

--- a/src/test/scala/userapp/LargeSpec.scala
+++ b/src/test/scala/userapp/LargeSpec.scala
@@ -62,7 +62,7 @@ import org.scalatest.{FreeSpec, Matchers}
 import scala.concurrent.ExecutionContext.Implicits.global
 
 class LargeSpec extends FreeSpec with Matchers with ScalaFutures {
-  implicit val patience = PatienceConfig(timeout = Span(2, Seconds), interval = Span(250, Millis))
+  implicit val patience = PatienceConfig(timeout = Span(90, Seconds), interval = Span(250, Millis))
 
   "slick tables with >22 column mappings" - {
     "should support inserts and selects" in {

--- a/src/test/scala/userapp/LargeSpec.scala
+++ b/src/test/scala/userapp/LargeSpec.scala
@@ -55,14 +55,9 @@ class LargeTable(tag: Tag) extends Table[Large](tag, "large") {
   ).mappedWith(Generic[Large])
 }
 
-import org.scalatest.{Tag => _, _}
-import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.time.{Millis, Seconds, Span}
-import org.scalatest.{FreeSpec, Matchers}
 import scala.concurrent.ExecutionContext.Implicits.global
 
-class LargeSpec extends FreeSpec with Matchers with ScalaFutures {
-  implicit val patience = PatienceConfig(timeout = Span(90, Seconds), interval = Span(250, Millis))
+class LargeSpec extends slickless.Spec {
 
   "slick tables with >22 column mappings" - {
     "should support inserts and selects" in {

--- a/src/test/scala/userapp/LargeSpec.scala
+++ b/src/test/scala/userapp/LargeSpec.scala
@@ -62,7 +62,7 @@ import org.scalatest.{FreeSpec, Matchers}
 import scala.concurrent.ExecutionContext.Implicits.global
 
 class LargeSpec extends FreeSpec with Matchers with ScalaFutures {
-  implicit val patience = PatienceConfig(timeout = Span(1, Seconds), interval = Span(250, Millis))
+  implicit val patience = PatienceConfig(timeout = Span(2, Seconds), interval = Span(250, Millis))
 
   "slick tables with >22 column mappings" - {
     "should support inserts and selects" in {


### PR DESCRIPTION
Version bumps for:

- Scala (2.12.x, 2.11.x)
- shapeless
- sbt (to 1.0.x)
- scoverage

🔨  I centralised the ScalaTest configuration into a new file called `Spec.scala`. Because...

💀 I increased the timeouts for scalatest _a lot_ to get the build to pass in travis-ci --- it can probably can come down from 30 seconds