### PR TITLE
add example of nesting case classes

### DIFF
--- a/src/test/scala/slickless/NestedSpec.scala
+++ b/src/test/scala/slickless/NestedSpec.scala
@@ -12,12 +12,12 @@ class NestedSpec extends Spec {
   case class Employee(id: Long, dept: Department, email: String)
 
   class Employees(tag: Tag) extends Table[Employee](tag, "emps") {
-    def id              = column[Long]( "id", O.PrimaryKey, O.AutoInc )
-    def department_id   = column[Long]("dept_id")
-    def department_city = column[String]("dept_city")
-    def email           = column[String]("email")
+    def id             = column[Long]("id", O.PrimaryKey, O.AutoInc)
+    def departmentId   = column[Long]("dept_id")
+    def departmentCity = column[String]("dept_city")
+    def email          = column[String]("email")
 
-    def department = (department_id, department_city).mapTo[Department]
+    def department = (departmentId, departmentCity).mapTo[Department]
 
     def * = (id :: department :: email :: HNil).mappedWith(Generic[Employee])
   }

--- a/src/test/scala/slickless/NestedSpec.scala
+++ b/src/test/scala/slickless/NestedSpec.scala
@@ -1,0 +1,43 @@
+package slickless
+
+import shapeless.{HNil, Generic}
+import slick.jdbc.H2Profile.api._
+
+import scala.concurrent.ExecutionContext.Implicits.global
+
+class Nested extends Spec {
+
+  case class Department(id: Long, city: String)
+
+  case class Employee(id: Long, dept: Department, email: String)
+
+  class Employees(tag: Tag) extends Table[Employee](tag, "emps") {
+    def id              = column[Long]( "id", O.PrimaryKey, O.AutoInc )
+    def department_id   = column[Long]("dept_id")
+    def department_city = column[String]("dept_city")
+    def email           = column[String]("email")
+
+    def department = (department_id, department_city).mapTo[Department]
+
+    def * = (id :: department :: email :: HNil).mappedWith(Generic[Employee])
+  }
+
+  lazy val emps = TableQuery[Employees]
+
+  "slick tables with nexted case class mappings" - {
+    "should support inserts and selects" in {
+      val db = Database.forConfig("h2")
+
+      val emp = Employee(1L, Department(42L, "Brighton"), "dave@example.org")
+
+      val action = for {
+        _   <- emps.schema.create
+        _   <- emps += emp
+        ans <- emps.result.head
+        _   <- emps.schema.drop
+      } yield ans
+
+      whenReady(db.run(action)) { _ should equal(emp) }
+    }
+  }
+}

--- a/src/test/scala/slickless/NestedSpec.scala
+++ b/src/test/scala/slickless/NestedSpec.scala
@@ -5,7 +5,7 @@ import slick.jdbc.H2Profile.api._
 
 import scala.concurrent.ExecutionContext.Implicits.global
 
-class Nested extends Spec {
+class NestedSpec extends Spec {
 
   case class Department(id: Long, city: String)
 
@@ -24,7 +24,7 @@ class Nested extends Spec {
 
   lazy val emps = TableQuery[Employees]
 
-  "slick tables with nexted case class mappings" - {
+  "slick tables with nested case class mappings" - {
     "should support inserts and selects" in {
       val db = Database.forConfig("h2")
 


### PR DESCRIPTION
This is using the standard Slick `mapTo[T]` to create a shape we can use in a `mappedWith` call.