### PR TITLE
Fix deprecation

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,9 @@ Licensed [Apache 2][license].
 
 | Scala | Slick    | Slickless |
 |-------|----------|----------|
+| 2.13  | 3.3      | [![Maven Central](https://maven-badges.herokuapp.com/maven-central/io.underscore/slickless_2.13/badge.svg)](https://maven-badges.herokuapp.com/maven-central/io.underscore/slickless_2.12) |
 | 2.12  | 3.3      | [![Maven Central](https://maven-badges.herokuapp.com/maven-central/io.underscore/slickless_2.12/badge.svg)](https://maven-badges.herokuapp.com/maven-central/io.underscore/slickless_2.12) |
-| 2.11  | 3.1      | [![Maven Central](https://maven-badges.herokuapp.com/maven-central/io.underscore/slickless_2.11/badge.svg)](https://maven-badges.herokuapp.com/maven-central/io.underscore/slickless_2.11) |
+| 2.11  | 3.1      | 0.3.0 |
 
 If you specifically need Slick 3.2, use [slickless 0.3.3](https://github.com/underscoreio/slickless/releases/tag/0.3.3).
 
@@ -28,7 +29,7 @@ Grab the code by adding the following to your `build.sbt`:
 
 ~~~
 libraryDependencies ++= Seq(
-  "com.typesafe.slick" %% "slick"     % "3.3.0",
+  "com.typesafe.slick" %% "slick"     % "3.3.2",
   "com.chuusai"        %% "shapeless" % "2.3.3",
   "io.underscore"      %% "slickless" % "<<VERSION>>"
 )

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 name         := "slickless"
 organization := "io.underscore"
 version      := "0.3.5-SNAPSHOT"
-scalaVersion := "2.12.8"
+scalaVersion := "2.13.0"
 
 crossScalaVersions := Seq("2.11.12", "2.12.8", "2.13.0")
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.1")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.6.0")

--- a/src/test/scala/slickless/Spec.scala
+++ b/src/test/scala/slickless/Spec.scala
@@ -2,9 +2,10 @@ package slickless
 
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.time.{Millis, Seconds, Span}
-import org.scalatest.{FreeSpec, Matchers}
+import org.scalatest.Matchers
+import org.scalatest.freespec.AnyFreeSpec
 
-abstract class Spec extends FreeSpec with Matchers with ScalaFutures {
+abstract class Spec extends AnyFreeSpec with Matchers with ScalaFutures {
   implicit val patience = PatienceConfig(timeout = Span(30, Seconds), interval = Span(250, Millis))
 }
 


### PR DESCRIPTION
...which as we have no warnings enabled, was failing the build.

Also:

- clarified which version of slickless to use with older version of Slick (#34)
- default `build.sbt` to Scala 2.13
