### PR TITLE
Fix error introduced in removing existentials

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ organization := "io.underscore"
 version      := "0.3.6-SNAPSHOT"
 scalaVersion := "2.13.0"
 
-crossScalaVersions := Seq("2.11.12", "2.12.8", "2.13.0")
+crossScalaVersions := Seq("2.11.12", "2.12.9", "2.13.0")
 
 licenses += ("Apache-2.0", url("http://apache.org/licenses/LICENSE-2.0"))
 

--- a/src/main/scala/slickless/HListShape.scala
+++ b/src/main/scala/slickless/HListShape.scala
@@ -38,7 +38,7 @@ trait HListShapeImplicits {
     new HListShape(Nil)
 
   implicit def hconsShape[
-    L <: ShapeLevel, L1 <: L, L2 <: L,
+    L <: ShapeLevel, L1 <: ShapeLevel, L2 <: ShapeLevel, 
     M1, M2 <: HList,
     U1, U2 <: HList,
     P1, P2 <: HList

--- a/src/test/scala/slickless/NestedSpec.scala
+++ b/src/test/scala/slickless/NestedSpec.scala
@@ -31,6 +31,7 @@ class NestedSpec extends Spec {
       val emp = Employee(1L, Department(42L, "Brighton"), "dave@example.org")
 
       val action = for {
+        _   <- emps.schema.drop.asTry
         _   <- emps.schema.create
         _   <- emps += emp
         ans <- emps.result.head

--- a/src/test/scala/userapp/Issue42.scala
+++ b/src/test/scala/userapp/Issue42.scala
@@ -1,0 +1,46 @@
+import slickless.Spec
+import shapeless.{HNil, Generic}
+import slick.jdbc.H2Profile.api._
+import slickless._
+import scala.concurrent.ExecutionContext.Implicits.global
+
+class Issue42 extends Spec {
+
+  case class Department(id: Long, city: String)
+
+  case class Employee(id: Long, dept1: Department, dept2: Department, email: String)
+
+  class Employees(tag: Tag) extends Table[Employee](tag, "emps42") {
+    def id              = column[Long]("id", O.PrimaryKey, O.AutoInc)
+    def departmentIdA   = column[Long]("dept_a_id")
+    def departmentCityA = column[String]("dept_a_city")
+    def departmentIdB   = column[Long]("dept_b_id")
+    def departmentCityB = column[String]("dept_b_city")
+    def email           = column[String]("email")
+
+    def departmentA = (departmentIdA, departmentCityA).mapTo[Department]
+    def departmentB = (departmentIdB, departmentCityB).mapTo[Department]
+
+    def * = (id :: departmentA :: departmentB :: email :: HNil).mappedWith(Generic[Employee])
+  }
+
+  lazy val emps = TableQuery[Employees]
+
+  "slick tables with nested case class mappings" - {
+    "should support inserts and selects" in {
+      val db = Database.forConfig("h2")
+
+      val emp = Employee(1L, Department(21L, "Brighton"), Department(22L, "Hove"), "dave@example.org")
+
+      val action = for {
+        _   <- emps.schema.drop.asTry
+        _   <- emps.schema.create
+        _   <- emps += emp
+        ans <- emps.result.head
+        _   <- emps.schema.drop
+      } yield ans
+
+      whenReady(db.run(action)) { _ should equal(emp) }
+    }
+  }
+}


### PR DESCRIPTION
Fixes #42 

This reverts [a change](https://github.com/underscoreio/slickless/pull/20/commits/7b484cfc1c88bb2476d800bc574dbc7159d396b5#diff-a40d3450d42d36bd05162269194a12e7L40-L43) where we'd incorrectly replaced `_` with a constraint on `L` rather than on `Shapelevel`.