### PR TITLE
Update to Slick 3.6

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,9 +1,9 @@
 name         := "slickless"
 organization := "io.underscore"
 version      := "0.3.7-SNAPSHOT"
-scalaVersion := "2.13.1"
+scalaVersion := "2.13.18"
 
-crossScalaVersions := Seq("2.11.12", "2.12.10", "2.13.1")
+crossScalaVersions := Seq("2.12.21", "2.13.18")
 
 licenses += ("Apache-2.0", url("http://apache.org/licenses/LICENSE-2.0"))
 
@@ -20,7 +20,7 @@ scalacOptions ++= Seq(
 )
 
 libraryDependencies ++= Seq(
-  "com.typesafe.slick" %% "slick"           % "3.3.2",
+  "com.typesafe.slick" %% "slick"           % "3.6.1",
   "com.chuusai"        %% "shapeless"       % "2.3.3",
   "org.scalatest"      %% "scalatest"       % "3.2.0-M4"   % "test",
   "com.h2database"      % "h2"              % "1.4.200" % "test",

--- a/src/main/scala/slickless/HListShape.scala
+++ b/src/main/scala/slickless/HListShape.scala
@@ -53,7 +53,7 @@ trait HListShapeImplicits {
       R: ClassTag, U <: HList, L <: FlatShapeLevel, P
     ](gen: Generic.Aux[R, U])(
       implicit shape: Shape[L, T, U, P]
-    ) = new MappedProjection[R, U](
+    ) = new MappedProjection[R](
       shape.toNode(hlist),
       MappedScalaType.Mapper(
         (gen.to _).asInstanceOf[Any => Any],

--- a/src/test/scala/slickless/Spec.scala
+++ b/src/test/scala/slickless/Spec.scala
@@ -6,7 +6,7 @@ import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
 
 abstract class Spec extends AnyFreeSpec with Matchers with ScalaFutures {
-  implicit val patience = PatienceConfig(timeout = Span(30, Seconds), interval = Span(250, Millis))
+  implicit val patience: PatienceConfig = PatienceConfig(timeout = Span(30, Seconds), interval = Span(250, Millis))
 }
 
 


### PR DESCRIPTION
The library doesn't work anymore when using Slick 3.6 because of the parametrized type added to `MappedProjection`. This PR updates the version of Slick and fix the compilation issue it introduce.